### PR TITLE
fix: Linux compatibility issues in load_secrets()

### DIFF
--- a/clother.sh
+++ b/clother.sh
@@ -265,14 +265,14 @@ load_secrets() {
     error "Secrets file is a symlink - refusing for security"; return 1
   fi
   local perms
-  perms=$(stat -f "%Lp" "$SECRETS_FILE" 2>/dev/null || stat -c "%a" "$SECRETS_FILE" 2>/dev/null || echo "000")
+  perms=$(stat -c "%a" "$SECRETS_FILE" 2>/dev/null || stat -f "%Lp" "$SECRETS_FILE" 2>/dev/null || echo "000")
   if [[ "$perms" != "600" ]]; then
     warn "Fixing secrets file permissions"; chmod 600 "$SECRETS_FILE"
   fi
   # Validate file format before sourcing
   local line_num=0
   while IFS= read -r line || [[ -n "$line" ]]; do
-    ((line_num++))
+    ((++line_num))
     # Skip empty lines and comments
     [[ -z "$line" ]] && continue
     [[ "$line" =~ ^[[:space:]]*# ]] && continue


### PR DESCRIPTION
Two bugs fixed:

1. stat command order: On Linux, stat -f outputs filesystem info instead of file permissions. Swapped to try stat -c (Linux) first, then stat -f (macOS/BSD).

2. Arithmetic increment: ((line_num++)) returns exit code 1 when line_num is 0, causing script to exit with set -e. Changed to ((++line_num)).