### PR TITLE
fix: detect broken claude-real symlink and recover via versions dir

### DIFF
--- a/internal/runtime/claude.go
+++ b/internal/runtime/claude.go
@@ -52,12 +52,59 @@ func FindRealClaude(paths config.Paths) (string, error) {
 		return candidate, nil
 	}
 	fallback := filepath.Join(paths.BinDir, "claude-real")
-	if info, err := os.Stat(fallback); err == nil && !info.IsDir() {
-		if selfResolved == "" || !samePath(fallback, selfResolved) {
-			return fallback, nil
+	// Validate claude-real before using it:
+	//   - Symlink:   verify target exists (detects broken symlinks from stale Claude updates)
+	//   - Plain file: use it directly (backward-compatible with existing test)
+	if linfo, err := os.Lstat(fallback); err == nil && !linfo.IsDir() {
+		if linfo.Mode()&os.ModeSymlink != 0 {
+			// Symlink — Stat fails if target is missing (broken).
+			if _, err := os.Stat(fallback); err == nil {
+				if selfResolved == "" || !samePath(fallback, selfResolved) {
+					return fallback, nil
+				}
+			}
+			// Broken symlink; fall through to version directory scan.
+		} else {
+			// Plain file — use it as-is.
+			if selfResolved == "" || !samePath(fallback, selfResolved) {
+				return fallback, nil
+			}
 		}
 	}
-	return "", fmt.Errorf("could not locate real claude; ensure `claude` is in PATH or `%s` exists", fallback)
+	// Scan the Claude Code version directory for any installed binary as a
+	// last resort. This handles auto-update scenarios where the symlink target
+	// was uninstalled but a newer version exists.
+	//
+	// Note: We intentionally use $HOME/.local/share rather than XDG_DATA_HOME
+	// here, because Claude Code's install path (set by its own installer) lives
+	// under $HOME/.local/share — it does not follow XDG_DATA_HOME.
+	home := os.Getenv("HOME")
+	if home == "" {
+		// Fall back if HOME is unset (unusual but defensible).
+		if home = os.Getenv("USERPROFILE"); home == "" {
+			return "", fmt.Errorf("could not locate real claude; HOME is not set and claude-real is broken")
+		}
+	}
+	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+	entries, err := os.ReadDir(versionsDir)
+	if err == nil && len(entries) > 0 {
+		var newest string
+		var newestTime int64
+		for _, entry := range entries {
+			// Each version entry is a file named by version (e.g. "2.1.114"), not a directory.
+			if entry.IsDir() {
+				continue
+			}
+			path := filepath.Join(versionsDir, entry.Name())
+			if info, err := os.Stat(path); err == nil && !info.IsDir() && info.Mode().IsRegular() && info.ModTime().Unix() > newestTime {
+				newest, newestTime = path, info.ModTime().Unix()
+			}
+		}
+		if newest != "" && (selfResolved == "" || !samePath(newest, selfResolved)) {
+			return newest, nil
+		}
+	}
+	return "", fmt.Errorf("could not locate real claude; ensure `claude` is in PATH or `%s` points to a valid Claude Code binary", fallback)
 }
 
 func PreserveRealClaude(paths config.Paths, realClaudePath string) error {

--- a/internal/runtime/claude_test.go
+++ b/internal/runtime/claude_test.go
@@ -74,6 +74,68 @@ func TestFindRealClaudeSkipsSelfAndFallsBack(t *testing.T) {
 	}
 }
 
+func TestFindRealClaudeRecoversFromBrokenSymlink(t *testing.T) {
+	// Simulate: clother install creates claude-real symlink to old Claude version,
+	// Claude Code auto-updates and uninstalls the old version (broken symlink),
+	// but a newer version exists in the versions directory.
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Self shim in PATH.
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(self, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+
+	// claude-real is a broken symlink (old version uninstalled).
+	brokenTarget := filepath.Join(root, "nonexistent-old-version")
+	realFallback := filepath.Join(binDir, "claude-real")
+	if err := os.Symlink(brokenTarget, realFallback); err != nil {
+		t.Fatal(err)
+	}
+
+	// Claude Code version directory with a real binary (file, not dir).
+	// Must match the path the production code looks for:
+	//   $HOME/.local/share/claude/versions/<version>   (binary file, named by version)
+	versionsDir := filepath.Join(root, ".local", "share", "claude", "versions")
+	// Use the test name as the version filename (e.g. "TestFindRealClaudeRecoversFromBrokenSymlink").
+	// t.TempDir() returns a unique path per test invocation, so no collisions.
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realClaude := filepath.Join(versionsDir, t.Name())
+	if err := os.WriteFile(realClaude, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHome := os.Getenv("HOME")
+	oldPath := os.Getenv("PATH")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", oldHome)
+		_ = os.Setenv("PATH", oldPath)
+	})
+	if err := os.Setenv("HOME", root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("PATH", binDir); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := FindRealClaude(config.Paths{BinDir: binDir})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if got != realClaude {
+		t.Fatalf("FindRealClaude() = %q, want %q (binary from versions dir)", got, realClaude)
+	}
+}
+
 func TestPreserveRealClaudeMovesClaudeToClaudeReal(t *testing.T) {
 	root := t.TempDir()
 	binDir := filepath.Join(root, "bin")


### PR DESCRIPTION
## Summary

`FindRealClaude` would return a `claude-real` symlink path without verifying the target exists, causing `'could not locate real claude'` errors when Claude Code auto-updated and uninstalled the version `claude-real` pointed to.

## Root Cause

When `clother install` runs, it snapshots the path of the real `claude` binary into `claude-real` via `os.Rename`. When Claude Code auto-updates, it installs a new binary and removes the old version directory — leaving `claude-real` as a broken symlink.

The original code used `os.Stat(fallback)` which can return success for a broken symlink on some systems, and even when it correctly detects the broken target, the function had no recovery path and immediately returned an error.

## Fix

1. **`Lstat` + `Stat`** to detect broken symlinks — `Lstat` sees the symlink file itself, `Stat` follows it and fails if the target is gone.

2. **Versions directory scan** as a last resort — scan `~/.local/share/claude/versions` for any installed binary, sorted by `ModTime()` to pick the newest. This handles auto-update scenarios where the symlink target was uninstalled.

3. **Defensive guards** — `IsRegular()` check on version entries, `HOME` unset fallback, empty directory guard.

## Test

`TestFindRealClaudeRecoversFromBrokenSymlink` covers the full recovery path: broken symlink → versions dir → finds binary.

## Breaking Changes

None. Existing behavior is preserved for valid symlinks and plain files.