### PR TITLE
Default Z.AI to GLM-5.2 and add it to the model menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ brew install clother
 
 # 3. Start using it — all launchers are ready immediately
 clother-native                          # Use your Claude Pro/Max/Team subscription
-clother-zai                             # Z.AI (GLM-5)
+clother-zai                             # Z.AI (GLM-5.2)
 clother-zai --yolo                      # Skip permission prompts
 clother-kimi                            # Kimi (kimi-k2.5)
 clother config                          # Configure providers
@@ -74,7 +74,7 @@ curl -fsSL https://raw.githubusercontent.com/jolehuit/clother/main/scripts/insta
 
 # 3. Start using it
 clother-native                          # Use your Claude Pro/Max/Team subscription
-clother-zai                             # Z.AI (GLM-5)
+clother-zai                             # Z.AI (GLM-5.2)
 clother-zai --yolo                      # Skip permission prompts
 clother-kimi                            # Kimi (kimi-k2.5)
 clother-ollama --model qwen3-coder      # Local with Ollama
@@ -138,7 +138,7 @@ Routes to `brew upgrade clother` under Homebrew, or downloads the latest release
 
 ### Changing the Default Model
 
-Each provider launcher comes with a default model (for example `glm-5` for Z.AI). You can override it in two ways:
+Each provider launcher comes with a default model (for example `glm-5.2` for Z.AI). You can override it in two ways:
 
 ```bash
 # One-time: pass --model through to Claude CLI

--- a/internal/providers/catalog.json
+++ b/internal/providers/catalog.json
@@ -24,13 +24,17 @@
       "auth_mode": "secret",
       "key_var": "ZAI_API_KEY",
       "base_url": "https://api.z.ai/api/anthropic",
-      "default_model": "glm-5",
+      "default_model": "glm-5.2",
       "model_tiers": {
-        "haiku": "glm-5",
-        "sonnet": "glm-5",
-        "opus": "glm-5"
+        "haiku": "glm-5.2",
+        "sonnet": "glm-5.2",
+        "opus": "glm-5.2"
       },
       "model_choices": [
+        {
+          "id": "glm-5.2",
+          "description": "GLM-5.2"
+        },
         {
           "id": "glm-5",
           "description": "GLM-5"


### PR DESCRIPTION
## What
Make the `zai` (Z.AI International) launcher default to `glm-5.2`, and surface it in `clother config zai`:
- `default_model` and all three `model_tiers` (haiku/sonnet/opus) → `glm-5.2`
- Add `glm-5.2` to `model_choices` (kept `glm-5` and `glm-4.7`)
- README references updated to match

## Why
`glm-5.2` is Z.AI's current flagship. The launcher previously defaulted to the rolling `glm-5` alias — it resolves to glm-5.2 server-side today, but will silently drift as Z.AI advances the alias. Pinning the explicit version keeps the default predictable, and listing glm-5.2 in the menu lets users select it without typing it by hand.

## Verification
- `glm-5.2` confirmed live on `https://api.z.ai/api/anthropic` (the endpoint returns `model: glm-5.2`).
- `go build ./...` clean; `go test ./...` green (the only failure is the pre-existing, network-dependent `TestRunInstallUpgradesToLatestRelease`, unrelated to this change).
- Scope limited to the international `zai` provider; `zai-cn` (open.bigmodel.cn) is intentionally left unchanged.

Note: this overlaps with #28 (which bumps the default to GLM-5.1); this targets the newer GLM-5.2.