### PR TITLE
Fix overlay crash when the config dir contains its own .claude.json

### DIFF
--- a/internal/runtime/config_overlay.go
+++ b/internal/runtime/config_overlay.go
@@ -126,7 +126,11 @@ func mirrorClaudeConfigDir(sourceDir, overlayDir string) error {
 		return err
 	}
 	for _, entry := range entries {
-		if entry.Name() == "settings.json" {
+		// settings.json is rewritten with the patched copy; .claude.json is the
+		// state file, mirrored separately by mirrorClaudeStateFile. Skipping it
+		// here avoids a symlink collision when the config dir also contains its
+		// own .claude.json alongside the home-level one.
+		if entry.Name() == "settings.json" || entry.Name() == ".claude.json" {
 			continue
 		}
 		src := filepath.Join(sourceDir, entry.Name())

--- a/internal/runtime/config_overlay_test.go
+++ b/internal/runtime/config_overlay_test.go
@@ -110,3 +110,57 @@ func TestPrepareClaudeConfigOverlaySkipsNativeClaude(t *testing.T) {
 		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want empty", got)
 	}
 }
+
+func TestPrepareClaudeConfigOverlayHandlesStateFileInsideConfigDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Some installs leave a .claude.json inside the config dir in addition to
+	// the canonical home-level one. Both previously mapped to the same overlay
+	// path and aborted the launch with "file exists".
+	if err := os.WriteFile(filepath.Join(claudeDir, ".claude.json"), []byte("{\"stale\":true}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	homeState := filepath.Join(home, ".claude.json")
+	if err := os.WriteFile(homeState, []byte("{\"home\":true}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	target := profiles.Target{Family: providers.FamilyAnthropicCompatibleNonClaude, Model: "glm-5.2"}
+	env, cleanup, err := PrepareClaudeConfigOverlay(target, nil, []string{
+		"PATH=/usr/bin",
+		"ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic",
+		"ANTHROPIC_AUTH_TOKEN=secret-token",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL=glm-5.2",
+	})
+	if err != nil {
+		t.Fatalf("overlay failed with .claude.json inside config dir: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	overlayDir := envSliceToMap(env)["CLAUDE_CONFIG_DIR"]
+	if overlayDir == "" {
+		t.Fatal("expected CLAUDE_CONFIG_DIR override")
+	}
+	statePath := filepath.Join(overlayDir, ".claude.json")
+	if info, err := os.Lstat(statePath); err != nil {
+		t.Fatalf("overlay .claude.json missing: %v", err)
+	} else if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected %s to be a symlink", statePath)
+	}
+	// The canonical home-level state file must be mirrored, not the in-dir copy.
+	resolved, err := os.Readlink(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != homeState {
+		t.Fatalf("overlay state points to %q, want home state %q", resolved, homeState)
+	}
+}


### PR DESCRIPTION
## Problem
`clother-<provider>` aborts immediately for any user whose Claude config dir holds a `.claude.json` *in addition to* the home-level `~/.claude.json`:

```
symlink ~/.claude.json /var/folders/.../clother-claude-config-XXXX/.claude.json: file exists
```

## Cause
`PrepareClaudeConfigOverlay` builds the temp `CLAUDE_CONFIG_DIR` by symlinking every entry of the config dir (`mirrorClaudeConfigDir`) and then separately symlinking the home-level state file (`mirrorClaudeStateFile`). When the config dir itself also contains a `.claude.json`, both resolve to the same `<overlay>/.claude.json`, so the second `os.Symlink` fails with `file exists`.

## Fix
Skip `.claude.json` in `mirrorClaudeConfigDir`, exactly as `settings.json` is already skipped — the state file is owned solely by `mirrorClaudeStateFile`, which mirrors the canonical home-level `~/.claude.json`. One-line change.

## Test
Adds `TestPrepareClaudeConfigOverlayHandlesStateFileInsideConfigDir`, which reproduces the collision (a `.claude.json` both inside the config dir and at home). It fails on `main` with the exact `file exists` error and passes with the fix, asserting the overlay's `.claude.json` resolves to the home-level state file.

`go build ./...` and `go test ./...` pass (the only failure, `TestRunInstallUpgradesToLatestRelease`, is a pre-existing network-dependent flake unrelated to this change).